### PR TITLE
A bunch of fixes from dkorunic's fork

### DIFF
--- a/app/app.iml
+++ b/app/app.iml
@@ -79,6 +79,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 21 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/app/app.iml
+++ b/app/app.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$USER_HOME$/AndroidstudioProjects/NetworkMapper" external.system.id="GRADLE" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>

--- a/app/src/main/java/org/kost/nmap/android/networkmapper/MainActivity.java
+++ b/app/src/main/java/org/kost/nmap/android/networkmapper/MainActivity.java
@@ -113,7 +113,7 @@ public class MainActivity extends ActionBarActivity {
         }
     }
 
-    void askToDownload() {
+    private void askToDownload() {
         DialogInterface.OnClickListener dialogClickListener = new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
@@ -130,7 +130,7 @@ public class MainActivity extends ActionBarActivity {
                 .show();
     }
 
-    void displaySuInfo() {
+    private void displaySuInfo() {
         if (canRunRootCommands()) {
             outputView.append(getString(R.string.info_gotroot));
             shellToRun="su";
@@ -139,11 +139,11 @@ public class MainActivity extends ActionBarActivity {
         }
     }
 
-    String PoorManFilter(String str) {
+    private String PoorManFilter(String str) {
         return str.replaceAll("[^A-Za-z0-9_ ./-]","");
     }
 
-    String getIPs() {
+    private String getIPs() {
         String interfaces="";
         try {
             for (Enumeration<NetworkInterface> en = NetworkInterface.getNetworkInterfaces(); en.hasMoreElements();) {
@@ -301,7 +301,7 @@ public class MainActivity extends ActionBarActivity {
         return retval;
     }
 
-    boolean isBinaryHere(boolean displayOutput) {
+    private boolean isBinaryHere(boolean displayOutput) {
         File nmapfile = new File(nmapbin);
         if (nmapfile.canExecute()) {
             if (displayOutput) {
@@ -579,7 +579,7 @@ public class MainActivity extends ActionBarActivity {
 
     }
 
-        private class SimpleHttpTask extends AsyncTask<String, Void, String> {
+    private class SimpleHttpTask extends AsyncTask<String, Void, String> {
         private final Context context;
         private PowerManager.WakeLock mWakeLock;
 
@@ -745,7 +745,7 @@ public class MainActivity extends ActionBarActivity {
         });
     }
 
-    void downloadData(final String prefixfn) {
+    private void downloadData(final String prefixfn) {
         String root = Environment.getExternalStorageDirectory().toString();
         final String datadldir = root + "/opt";
 

--- a/app/src/main/java/org/kost/nmap/android/networkmapper/MainActivity.java
+++ b/app/src/main/java/org/kost/nmap/android/networkmapper/MainActivity.java
@@ -160,7 +160,7 @@ public class MainActivity extends ActionBarActivity {
                 for (Enumeration<InetAddress> enumIpAddr = intf.getInetAddresses(); enumIpAddr.hasMoreElements();) {
                     InetAddress inetAddress = enumIpAddr.nextElement();
                     if (!inetAddress.isLoopbackAddress()) {
-                        interfaces=interfaces+"[IP]: "+inetAddress.getHostAddress().toString()+"\n";
+                        interfaces=interfaces+"[IP]: "+ inetAddress.getHostAddress() +"\n";
                     }
                 }
             }
@@ -677,9 +677,9 @@ public class MainActivity extends ActionBarActivity {
     String donexteabi() {
         switch (currentEabi++) {
             case 0:
-                return Build.CPU_ABI.toString();
+                return Build.CPU_ABI;
             case 1:
-                return Build.CPU_ABI2.toString();
+                return Build.CPU_ABI2;
         }
         return null;
     }
@@ -706,7 +706,7 @@ public class MainActivity extends ActionBarActivity {
                     if (nextEabi==null) {
                         Toast.makeText(context, "Binary download error: " + result, Toast.LENGTH_LONG).show();
                     } else {
-                        Toast.makeText(context, "Trying next architecture: "+nextEabi.toString(),Toast.LENGTH_LONG).show();
+                        Toast.makeText(context, "Trying next architecture: "+ nextEabi,Toast.LENGTH_LONG).show();
                         downloadBinary(prefixfn, nextEabi);
                     }
                     return;

--- a/app/src/main/java/org/kost/nmap/android/networkmapper/MainActivity.java
+++ b/app/src/main/java/org/kost/nmap/android/networkmapper/MainActivity.java
@@ -791,7 +791,7 @@ public class MainActivity extends ActionBarActivity {
                         if (oldver!="" && oldver!=prefixfn) {
                             SharedPreferences.Editor editor = sharedPref.edit();
                             editor.putString(getString(R.string.nmapbin_version), prefixfn);
-                            editor.commit();
+                            editor.apply();
                             Log.i("NetworkMapper","deleting recursively!");
                             DeleteRecursive(new File(datadldir + "/" + prefixfn));
                         } else {
@@ -824,7 +824,7 @@ public class MainActivity extends ActionBarActivity {
                 });
 
                 mWakeLock.release();
-            };
+            }
         };
         Log.i("NetworkMapper", "Executing using: " + nmapurl + "/" + datafn );
         dataTask.execute(nmapurl + "/" + datafn, datadldir + "/" + datafn, prefixfn, datadldir);

--- a/app/src/main/java/org/kost/nmap/android/networkmapper/MainActivity.java
+++ b/app/src/main/java/org/kost/nmap/android/networkmapper/MainActivity.java
@@ -277,33 +277,30 @@ public class MainActivity extends ActionBarActivity {
             suProcess = Runtime.getRuntime().exec("su");
             DataOutputStream os = new DataOutputStream(suProcess.getOutputStream());
             DataInputStream osRes = new DataInputStream(suProcess.getInputStream());
-            if (null != os && null != osRes)
+            os.writeBytes("id\n");
+            os.flush();
+            String currUid = osRes.readLine();
+            boolean exitSu = false;
+            if (null == currUid)
             {
-                os.writeBytes("id\n");
-                os.flush();
-                String currUid = osRes.readLine();
-                boolean exitSu = false;
-                if (null == currUid)
-                {
-                    retval = false;
-                    exitSu = false;
-                }
-                else if (currUid.contains("uid=0"))
-                {
-                    retval = true;
-                    exitSu = true;
-                }
-                else
-                {
-                    retval = false;
-                    exitSu = true;
-                }
+                retval = false;
+                exitSu = false;
+            }
+            else if (currUid.contains("uid=0"))
+            {
+                retval = true;
+                exitSu = true;
+            }
+            else
+            {
+                retval = false;
+                exitSu = true;
+            }
 
-                if (exitSu)
-                {
-                    os.writeBytes("exit\n");
-                    os.flush();
-                }
+            if (exitSu)
+            {
+                os.writeBytes("exit\n");
+                os.flush();
             }
         }
         catch (Exception e)
@@ -375,6 +372,7 @@ public class MainActivity extends ActionBarActivity {
                 while ((pstdout = inputStream.readLine()) != null) {
                     pstderr=null;
                     Log.i("NetworkMapper","Stdout: "+pstdout);
+                    // XXX: pstderr is always null
                     Log.i("NetworkMapper","Stderr: "+pstderr);
                     publishProgress(pstdout+"\n",pstderr);
                 }
@@ -383,6 +381,7 @@ public class MainActivity extends ActionBarActivity {
                 throw new RuntimeException(e);
             }
 
+            // XXX: pstdout is always null
             return pstdout;
         }
 
@@ -650,6 +649,7 @@ public class MainActivity extends ActionBarActivity {
             mWakeLock.release();
             sharedProgressDialog.dismiss();
             if (result == null) {
+                // XXX reporting with null doesn't make sense
                 Toast.makeText(context, "Version download error: " + result, Toast.LENGTH_LONG).show();
                 return;
             }

--- a/app/src/main/java/org/kost/nmap/android/networkmapper/MainActivity.java
+++ b/app/src/main/java/org/kost/nmap/android/networkmapper/MainActivity.java
@@ -59,8 +59,6 @@ public class MainActivity extends ActionBarActivity {
 
     private SharedPreferences sharedPrefs;
 
-    private String appdir;
-    private String bindir;
     private String nmapbin;
     private String shellToRun;
 
@@ -96,15 +94,16 @@ public class MainActivity extends ActionBarActivity {
 
         String binarydir=sharedPrefs.getString("pref_binaryloc",getResources().getString(R.string.pref_default_binaryloc));
 
-        appdir = getFilesDir().getParent();
+        String appdir = getFilesDir().getParent();
+        String bindir;
         if (binarydir.length()>0) {
-            bindir=binarydir;
+            bindir =binarydir;
         } else {
             bindir = appdir + "/bin";
         }
-        nmapbin = bindir+"/nmap";
+        nmapbin = bindir +"/nmap";
         shellToRun="sh";
-        Log.i("NetworkMapper","bindir: "+bindir+" shell: "+shellToRun+" nmapbin: "+nmapbin);
+        Log.i("NetworkMapper","bindir: "+ bindir +" shell: "+shellToRun+" nmapbin: "+nmapbin);
 
         if (savedInstanceState != null) {
             Log.i("NetworkMapper","RestoreState()");

--- a/app/src/main/java/org/kost/nmap/android/networkmapper/MainActivity.java
+++ b/app/src/main/java/org/kost/nmap/android/networkmapper/MainActivity.java
@@ -26,6 +26,7 @@ import android.widget.Toast;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
@@ -35,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
@@ -275,9 +277,9 @@ public class MainActivity extends ActionBarActivity {
         try
         {
             suProcess = Runtime.getRuntime().exec("su");
-            DataOutputStream os = new DataOutputStream(suProcess.getOutputStream());
-            DataInputStream osRes = new DataInputStream(suProcess.getInputStream());
-            os.writeBytes("id\n");
+            BufferedWriter os = new BufferedWriter(new OutputStreamWriter(suProcess.getOutputStream()));
+            BufferedReader osRes = new BufferedReader(new InputStreamReader(suProcess.getInputStream()));
+            os.write("id\n");
             os.flush();
             String currUid = osRes.readLine();
             boolean exitSu;
@@ -299,7 +301,7 @@ public class MainActivity extends ActionBarActivity {
 
             if (exitSu)
             {
-                os.writeBytes("exit\n");
+                os.write("exit\n");
                 os.flush();
             }
         }

--- a/app/src/main/java/org/kost/nmap/android/networkmapper/MainActivity.java
+++ b/app/src/main/java/org/kost/nmap/android/networkmapper/MainActivity.java
@@ -48,21 +48,21 @@ import java.util.zip.ZipInputStream;
 
 
 public class MainActivity extends ActionBarActivity {
-    ProgressDialog sharedProgressDialog;
-    String nmapurl;
+    private ProgressDialog sharedProgressDialog;
+    private String nmapurl;
 
-    int currentEabi;
-    TextView outputView;
-    EditText editText;
-    ScrollView scrollView;
-    Spinner spinner;
+    private int currentEabi;
+    private TextView outputView;
+    private EditText editText;
+    private ScrollView scrollView;
+    private Spinner spinner;
 
-    SharedPreferences sharedPrefs;
+    private SharedPreferences sharedPrefs;
 
-    String appdir;
-    String bindir;
-    String nmapbin;
-    String shellToRun;
+    private String appdir;
+    private String bindir;
+    private String nmapbin;
+    private String shellToRun;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -118,7 +118,7 @@ public class MainActivity extends ActionBarActivity {
         }
     }
 
-    public void askToDownload () {
+    void askToDownload() {
         DialogInterface.OnClickListener dialogClickListener = new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
@@ -139,7 +139,7 @@ public class MainActivity extends ActionBarActivity {
                 .setNegativeButton("No", dialogClickListener).show();
     }
 
-    public void displaySuInfo() {
+    void displaySuInfo() {
         if (canRunRootCommands()) {
             outputView.append("Root access gained.\n");
             shellToRun="su";
@@ -148,11 +148,11 @@ public class MainActivity extends ActionBarActivity {
         }
     }
 
-    public String PoorManFilter (String str) {
+    String PoorManFilter(String str) {
         return str.replaceAll("[^A-Za-z0-9_ ./-]","");
     }
 
-    public String getIPs () {
+    String getIPs() {
         String interfaces="";
         try {
             for (Enumeration<NetworkInterface> en = NetworkInterface.getNetworkInterfaces(); en.hasMoreElements();) {
@@ -269,7 +269,7 @@ public class MainActivity extends ActionBarActivity {
         return super.onOptionsItemSelected(item);
     }
 
-    public static boolean canRunRootCommands()
+    private static boolean canRunRootCommands()
     {
         boolean retval = false;
         Process suProcess;
@@ -289,7 +289,7 @@ public class MainActivity extends ActionBarActivity {
                     retval = false;
                     exitSu = false;
                 }
-                else if (true == currUid.contains("uid=0"))
+                else if (currUid.contains("uid=0"))
                 {
                     retval = true;
                     exitSu = true;
@@ -314,7 +314,7 @@ public class MainActivity extends ActionBarActivity {
         return retval;
     }
 
-    public boolean isBinaryHere (boolean displayOutput) {
+    boolean isBinaryHere(boolean displayOutput) {
         File nmapfile = new File(nmapbin);
         if (nmapfile.canExecute()) {
             if (displayOutput) {
@@ -341,8 +341,8 @@ public class MainActivity extends ActionBarActivity {
     }
 
     private class ExecuteTask extends AsyncTask<String,String,String> {
-        protected Context context;
-        protected PowerManager.WakeLock mWakeLock;
+        final Context context;
+        PowerManager.WakeLock mWakeLock;
 
         @Override
         protected String doInBackground(String... sParm) {
@@ -426,11 +426,11 @@ public class MainActivity extends ActionBarActivity {
     }
 
     private class DownloadTask extends AsyncTask<String,Integer,String> {
-        protected Context context;
-        protected PowerManager.WakeLock mWakeLock;
-        protected String dlurl;
-        protected String dlfn;
-        protected String dlprefix;
+        final Context context;
+        PowerManager.WakeLock mWakeLock;
+        String dlurl;
+        String dlfn;
+        String dlprefix;
 
         @Override
         protected String doInBackground(String... sParm) {
@@ -525,11 +525,11 @@ public class MainActivity extends ActionBarActivity {
     }
 
     private class UnzipTask extends AsyncTask<String,Integer,String> {
-        private Context context;
+        private final Context context;
         private PowerManager.WakeLock mWakeLock;
-        protected int per;
-        protected String dlprefix;
-        protected int maxfiles;
+        int per;
+        String dlprefix;
+        int maxfiles;
 
         public UnzipTask(Context context) {
             this.context = context;
@@ -598,7 +598,7 @@ public class MainActivity extends ActionBarActivity {
     }
 
         private class SimpleHttpTask extends AsyncTask<String, Void, String> {
-        private Context context;
+        private final Context context;
         private PowerManager.WakeLock mWakeLock;
 
         public SimpleHttpTask(Context context) {
@@ -664,7 +664,7 @@ public class MainActivity extends ActionBarActivity {
 
     }
 
-    public void downloadAll () {
+    void downloadAll() {
         final SimpleHttpTask verTask = new SimpleHttpTask(this);
         verTask.execute(nmapurl + "/nmap-latest.txt");
 
@@ -676,7 +676,7 @@ public class MainActivity extends ActionBarActivity {
         });
     }
 
-    public String donexteabi () {
+    String donexteabi() {
         switch (currentEabi++) {
             case 0:
                 return Build.CPU_ABI.toString();
@@ -686,7 +686,7 @@ public class MainActivity extends ActionBarActivity {
         return null;
     }
 
-    public void downloadBinary (final String prefixfn,String eabi) {
+    void downloadBinary(final String prefixfn, String eabi) {
         String appdir = getFilesDir().getParent();
         String bindir = appdir + "/bin";
         String dldir = appdir + "/dl";
@@ -761,7 +761,7 @@ public class MainActivity extends ActionBarActivity {
         });
     }
 
-    public void downloadData (final String prefixfn) {
+    void downloadData(final String prefixfn) {
         String root = Environment.getExternalStorageDirectory().toString();
         final String datadldir = root + "/opt";
 

--- a/app/src/main/java/org/kost/nmap/android/networkmapper/MainActivity.java
+++ b/app/src/main/java/org/kost/nmap/android/networkmapper/MainActivity.java
@@ -164,7 +164,7 @@ public class MainActivity extends ActionBarActivity {
                     }
                 }
             }
-        } catch (SocketException ex) {
+        } catch (SocketException ignored) {
         }
         return interfaces;
     }
@@ -380,9 +380,7 @@ public class MainActivity extends ActionBarActivity {
                     publishProgress(pstdout+"\n",pstderr);
                 }
                 process.waitFor();
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            } catch (InterruptedException e) {
+            } catch (IOException | InterruptedException e) {
                 throw new RuntimeException(e);
             }
 

--- a/app/src/main/java/org/kost/nmap/android/networkmapper/MainActivity.java
+++ b/app/src/main/java/org/kost/nmap/android/networkmapper/MainActivity.java
@@ -785,7 +785,7 @@ public class MainActivity extends ActionBarActivity {
                         SharedPreferences sharedPref = context.getSharedPreferences(context.getPackageName() + "_preferences",Context.MODE_PRIVATE);
                         String oldver=sharedPref.getString(getString(R.string.nmapbin_version),"");
 
-                        if (oldver!="" && oldver!=prefixfn) {
+                        if (!oldver.equals("") && !oldver.equals(prefixfn)) {
                             SharedPreferences.Editor editor = sharedPref.edit();
                             editor.putString(getString(R.string.nmapbin_version), prefixfn);
                             editor.apply();

--- a/app/src/main/java/org/kost/nmap/android/networkmapper/MainActivity.java
+++ b/app/src/main/java/org/kost/nmap/android/networkmapper/MainActivity.java
@@ -186,7 +186,7 @@ public class MainActivity extends ActionBarActivity {
     public void onScanButtonClick (View v) {
         StringBuilder sbcmdline = new StringBuilder("");
 
-        String profileopt="";
+        String profileopt;
 
         // Spinner options - TODO: check if array is large enough
         String scanSwitches[]=getResources().getStringArray(R.array.scan_values_array);
@@ -270,7 +270,7 @@ public class MainActivity extends ActionBarActivity {
 
     private static boolean canRunRootCommands()
     {
-        boolean retval = false;
+        boolean retval;
         Process suProcess;
         try
         {
@@ -280,7 +280,7 @@ public class MainActivity extends ActionBarActivity {
             os.writeBytes("id\n");
             os.flush();
             String currUid = osRes.readLine();
-            boolean exitSu = false;
+            boolean exitSu;
             if (null == currUid)
             {
                 retval = false;
@@ -343,13 +343,12 @@ public class MainActivity extends ActionBarActivity {
         @Override
         protected String doInBackground(String... sParm) {
             String cmdline=sParm[0];
-            String pstdout=null;
-            String pstderr=null;
+            String pstdout;
+            String pstderr;
             String[] commands = { cmdline };
 
-            DataOutputStream outputStream = null;
-            BufferedReader inputStream, errorStream;
-            inputStream = errorStream = null;
+            DataOutputStream outputStream;
+            BufferedReader inputStream;
 
             try {
                 Process process = Runtime.getRuntime().exec(shellToRun);
@@ -357,15 +356,11 @@ public class MainActivity extends ActionBarActivity {
                 outputStream = new DataOutputStream(process.getOutputStream());
                 inputStream = new BufferedReader(new InputStreamReader(
                         process.getInputStream()));
-                errorStream = new BufferedReader(new InputStreamReader(
-                        process.getErrorStream()));
 
                 for (String single : commands) {
                     Log.i("NetworkMapper","Single Executing: "+single);
                     outputStream.writeBytes(single + "\n");
                     outputStream.flush();
-
-                    pstdout="";
                 }
                 outputStream.writeBytes("exit\n");
                 outputStream.flush();
@@ -546,7 +541,7 @@ public class MainActivity extends ActionBarActivity {
 
                 FileInputStream fin = new FileInputStream(zipfn);
                 ZipInputStream zin = new ZipInputStream(fin);
-                ZipEntry ze = null;
+                ZipEntry ze;
                 while ((ze = zin.getNextEntry()) != null) {
                     Log.v("NetworkMapper", "Unzipping " + ze.getName());
 
@@ -572,7 +567,7 @@ public class MainActivity extends ActionBarActivity {
 
                 }
                 zin.close();
-                boolean deleted = new File(zipfn).delete(); // delete file after successful unzip
+                new File(zipfn).delete(); // delete file after successful unzip
             } catch (Exception e) {
                 Log.e("NetowrkMapper", "unzip", e);
             }
@@ -605,7 +600,7 @@ public class MainActivity extends ActionBarActivity {
         protected String doInBackground(String... params) {
             String urllink = params[0];
 
-            String str=null;
+            String str;
             try {
                 URL url = new URL(urllink);
                 Log.i("NetworkMapper","Downloading from URL: "+url.toString());
@@ -725,7 +720,7 @@ public class MainActivity extends ActionBarActivity {
                         String[] commands = {"ncat", "ndiff", "nmap", "nping"};
                         try {
                             for (String singlecommand : commands) {
-                                Process process = Runtime.getRuntime().exec("/system/bin/chmod 755 " + bindir + singlecommand);
+                                Runtime.getRuntime().exec("/system/bin/chmod 755 " + bindir + singlecommand);
                             }
                         } catch (IOException e) {
                             Toast.makeText(context,"Error setting permissions", Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/org/kost/nmap/android/networkmapper/SettingsActivity.java
+++ b/app/src/main/java/org/kost/nmap/android/networkmapper/SettingsActivity.java
@@ -156,7 +156,7 @@ public class SettingsActivity extends PreferenceActivity {
      * A preference value change listener that updates the preference's summary
      * to reflect its new value.
      */
-    private static Preference.OnPreferenceChangeListener sBindPreferenceSummaryToValueListener = new Preference.OnPreferenceChangeListener() {
+    private static final Preference.OnPreferenceChangeListener sBindPreferenceSummaryToValueListener = new Preference.OnPreferenceChangeListener() {
         @Override
         public boolean onPreferenceChange(Preference preference, Object value) {
             String stringValue = value.toString();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,7 +17,7 @@
     <string name="action_share">Share</string>
     <string name="share_to">Share to</string>
     <string name="aboutdlg_title">About...</string>
-    <string name="aboutdlg_text">NetworkMapper\nCopyright (C) 2015. Vlatko Kosturjak\nhttps://github.com/kost/NetworkMapper/</string>
+    <string name="aboutdlg_text">NetworkMapper\nCopyright © 2015. Vlatko Kosturjak\nhttps://github.com/kost/NetworkMapper/</string>
 
     <string name="nmapbin_version">nmapbin_version</string>
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
```
- use preferences apply (background) instead of commit (foreground)
- remove unnecessary comma
- use private for fields when applicable
- use final for fields when applicable
- fix exceptions: merge exceptions when possible
- fix exceptions: ignored exceptions should be marked as such
- first part of string handling fixes: don't use toString() on objects
  already being string
- convert variables to local where applicable
- improve and comment on null handling
- strings are compared with equals()
- remove unnecessary variable initializations
- remove unused variables
- fix obsolete gradle dep
- replace (c) with proper Unicode symbol
- rewrite superuser checking code to use unicode-safe BufferedWriter
  BufferedWriter (note: obsolete readLine in DataInputStream)
- merge with upstream
- another batch of fixing public/private issues for package local methods
```
